### PR TITLE
Add quick-xml and remove serde-xml-rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
+/**/target
+/**/**/target
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"
-
 derives = { path = "derives" }
 parser = { path = "parser" }

--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -3,20 +3,16 @@
 version = 3
 
 [[package]]
-name = "derives"
-version = "0.1.0"
-dependencies = [
- "parser",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -32,6 +28,7 @@ dependencies = [
  "quick-xml",
  "quote",
  "serde",
+ "serde-xml-rs",
  "serde_json",
 ]
 
@@ -46,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "memchr",
  "serde",
@@ -79,6 +76,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +95,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -102,27 +111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siri_et_parser"
-version = "0.1.0"
-dependencies = [
- "derives",
- "parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,7 +122,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde-xml-rs = "0.6.0"
 serde_json = "1.0.108"
 quote = "1.0"
 proc-macro2 = "1.0"
+quick-xml = {version = "0.36.2", features = ["serialize"]}

--- a/parser/src/models/envelope.rs
+++ b/parser/src/models/envelope.rs
@@ -2,7 +2,6 @@ use std::fs;
 
 use quote::ToTokens;
 use serde::{Deserialize, Serialize};
-use serde_xml_rs::from_str;
 
 use super::body::Body;
 
@@ -20,13 +19,13 @@ impl Envelope {
 
     pub fn from_file(file_path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let content = fs::read_to_string(file_path)?;
-        let envelope = from_str(&content)?;
+        let envelope = quick_xml::de::from_str(&content)?;
         Ok(envelope)
     }
 
 
     pub fn from_str(xml_str: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let envelope = from_str(xml_str)?;
+        let envelope = quick_xml::de::from_str(xml_str)?;
         Ok(envelope)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use parser::models::envelope::Envelope;
 
 pub fn main(){
-    let envelope_resut = Envelope::from_file("src/fixtures/siri_et_xml_tn/trip_add.xml");
+    let envelope_resut = Envelope::from_file("src/fixtures/siri_et_xml_tn/siri-destineo-et-sbx.xml");
     assert!(envelope_resut.is_ok());
     println!("Trip Add XMLEnvelope: {:?}", envelope_resut.unwrap());
 }


### PR DESCRIPTION
Benchmark results
Big file (style Destineo):
```
quick-xml: test tests::benchmark_parsing_one_file ... bench:   1,559,000.77 ns/iter (+/- 176,981.27) / 1,559 ms per file
serde-xml-rs: test tests::benchmark_parsing_one_file ... bench:   7,027,579.10 ns/iter (+/- 915,966.61) / 7 ms per file
```

Small file (style TripAdd):

```
quick-xml: test tests::benchmark_parsing_one_file ... bench:      61,797.63 ns/iter (+/- 1,821.97) / 0,061 ms per file
serde-xml-rs: test tests::benchmark_parsing_one_file ... bench:     345,392.42 ns/iter (+/- 23,364.21)/ 0.3ms per file
```